### PR TITLE
fix(workflow): add token to install-dependencies step

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -36,9 +36,11 @@ jobs:
       
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          run_install: true
+          run_install: false
       
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm install
       


### PR DESCRIPTION
This PR should fix the following error when installing dependencies: https://github.com/pagopa/interop-probing-core/actions/runs/19850829027/job/56877098954#step:4:41 