### PR TITLE
fix: upgrade probing-frontend version

### DIFF
--- a/packages/probing-frontend/package.json
+++ b/packages/probing-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "probing-frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This PR upgrades the version of the `probing-frontend` package.
This edit is necessary to trigger the [frontend-build](https://github.com/pagopa/interop-probing-core/blob/develop/.github/workflows/frontend-build.yaml) workflow to test its execution. 