### PR TITLE
PIN-8699: ensure logger is silenced for /status endpoint

### DIFF
--- a/packages/probing-api/src/app.ts
+++ b/packages/probing-api/src/app.ts
@@ -55,10 +55,10 @@ export function createApp(operationsService: OperationsService) {
   app.use(express.urlencoded({ extended: true }));
   app.use(cors(corsOptions));
 
+  app.use(healthRouter);
   app.use(queryParamsMiddleware);
   app.use(contextMiddleware(config.applicationName));
   app.use(loggerMiddleware(config.applicationName));
-  app.use(healthRouter);
   app.use(eServiceRouter(zodiosCtx, operationsService));
 
   return app;

--- a/packages/probing-statistics-api/src/app.ts
+++ b/packages/probing-statistics-api/src/app.ts
@@ -55,9 +55,9 @@ export function createApp(statisticsService: StatisticsService) {
   app.use(express.urlencoded({ extended: true }));
   app.use(cors(corsOptions));
 
+  app.use(healthRouter);
   app.use(loggerMiddleware(config.applicationName));
   app.use(contextMiddleware(config.applicationName));
-  app.use(healthRouter);
   app.use(statisticsRouter(zodiosCtx, statisticsService));
 
   return app;


### PR DESCRIPTION
[Closes: [PIN-8699](https://pagopa.atlassian.net/browse/PIN-8699)]

[PIN-8699]: https://pagopa.atlassian.net/browse/PIN-8699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ