### PR TITLE
PIN-9334: add configurable request timeout for REST/SOAP calls probing-caller

### DIFF
--- a/packages/probing-caller/src/utilities/apiClientHandler.ts
+++ b/packages/probing-caller/src/utilities/apiClientHandler.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 import { createProbingRequestEnvelope } from "./soapEnvelope.js";
 import { AppContext, WithSQSMessageId } from "pagopa-interop-probing-commons";
+import { config } from "./config.js";
 
 export const apiClientBuilder = () => {
   return {
@@ -12,6 +13,7 @@ export const apiClientBuilder = () => {
       return await axios({
         method: "GET",
         url: baseUrl,
+        timeout: config.httpRequestTimeoutMs,
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
@@ -27,6 +29,7 @@ export const apiClientBuilder = () => {
       return await axios({
         method: "POST",
         url: baseUrl,
+        timeout: config.httpRequestTimeoutMs,
         headers: {
           "Content-Type": "text/xml;charset=UTF-8",
           Authorization: `Bearer ${token}`,

--- a/packages/probing-caller/src/utilities/config.ts
+++ b/packages/probing-caller/src/utilities/config.ts
@@ -20,6 +20,7 @@ const probingCallerConfig = AWSConfig.and(ConsumerConfig)
         JWT_PAYLOAD_ISSUER: z.string(),
         JWT_PAYLOAD_SUBJECT: z.string(),
         JWT_PAYLOAD_KID_KMS: z.string(),
+        HTTP_REQUEST_TIMEOUT_MS: z.coerce.number().min(1).default(5000),
       })
       .transform((c) => ({
         applicationName: c.INTEROP_PROBING_CALLER_NAME,
@@ -32,6 +33,7 @@ const probingCallerConfig = AWSConfig.and(ConsumerConfig)
         jwtPayloadIssuer: c.JWT_PAYLOAD_ISSUER,
         jwtPayloadSubject: c.JWT_PAYLOAD_SUBJECT,
         jwtPayloadKidKms: c.JWT_PAYLOAD_KID_KMS,
+        httpRequestTimeoutMs: c.HTTP_REQUEST_TIMEOUT_MS,
       })),
   );
 

--- a/packages/probing-caller/src/utilities/errorMapper.ts
+++ b/packages/probing-caller/src/utilities/errorMapper.ts
@@ -25,6 +25,7 @@ export const errorMapper = (error: unknown, logger: Logger) =>
 export function getKoReason(error: unknown): string {
   return match((error as AxiosError).code)
     .with("ECONNREFUSED", () => callerConstants.CONNECTION_REFUSED_KO_REASON)
+    .with("ECONNABORTED", () => callerConstants.CONNECTION_TIMEOUT_KO_REASON)
     .with("ETIMEDOUT", () => callerConstants.CONNECTION_TIMEOUT_KO_REASON)
     .otherwise(() => {
       const status = (error as AxiosError).response?.status;

--- a/packages/probing-caller/test/callerService.test.ts
+++ b/packages/probing-caller/test/callerService.test.ts
@@ -201,6 +201,56 @@ describe("caller service test", () => {
     );
   });
 
+  it("should mark REST probing as KO when axios aborts due to timeout", async () => {
+    const validMessage: SQS.Message = {
+      MessageId: "12345",
+      ReceiptHandle: "receipt_handle_id",
+      Body: JSON.stringify({
+        eserviceRecordId: 1,
+        technology: "REST",
+        basePath: ["path1", "path2"],
+        audience: ["aud1", "path2"],
+      }),
+      MessageAttributes: correlationIdMessageAttribute,
+    };
+
+    const { correlationId } = decodeSQSMessageCorrelationId(validMessage);
+    const ctx: WithSQSMessageId<AppContext> = {
+      serviceName: config.applicationName,
+      messageId: validMessage.MessageId,
+      correlationId,
+    };
+
+    const apiClientError = mockApiClientError(
+      500,
+      "timeout of 5000ms exceeded",
+      "ECONNABORTED",
+    );
+
+    vi.spyOn(apiClientHandler, "sendREST").mockRejectedValue(apiClientError);
+    vi.spyOn(kmsClientHandler, "buildJWT").mockResolvedValue(mockJWT);
+
+    const eservice = decodeSQSMessage<EserviceContentDto>(
+      validMessage,
+      EserviceContentDto,
+    );
+    const baseUrl = `${eservice.basePath[0]}${callerConstants.PROBING_ENDPOINT_SUFFIX}`;
+
+    const telemetryResult = await callerService.performRequest(eservice, ctx);
+
+    expect(telemetryResult.status).toBe("KO");
+    expect((telemetryResult as TelemetryKoDto).koReason).toBe(
+      callerConstants.CONNECTION_TIMEOUT_KO_REASON,
+    );
+    expect(telemetryResult.eserviceRecordId).toBe(eservice.eserviceRecordId);
+
+    expect(apiClientHandler.sendREST).toHaveBeenCalledWith(
+      baseUrl,
+      mockJWT,
+      ctx,
+    );
+  });
+
   it("should mark SOAP probing as OK when the service responds successfully", async () => {
     const validMessage: SQS.Message = {
       MessageId: "12345",


### PR DESCRIPTION
## Jira Issue  
[PIN-9334](https://pagopa.atlassian.net/browse/PIN-9334)

## Context / Why  

This PR makes probing HTTP calls in `probing-caller` deterministic by introducing a configurable request timeout.  
Previously, axios requests had no explicit timeout, so behavior depended on lower network/infrastructure timeouts.

## Services Impacted  
- probing-caller

## Key Changes  

### Configurable HTTP Request Timeout
Added env-based timeout configuration in `probing-caller` config:
- `HTTP_REQUEST_TIMEOUT_MS` (default `5000`)

### Timeout Applied to Outbound Probing Calls
Applied timeout to both outbound request types in `apiClientHandler`:
- REST (`GET /status`)
- SOAP (`POST /status`)

### Timeout Error Mapping Hardening
Updated timeout classification to treat both axios timeout error codes as `Connection timeout`:
- `ECONNABORTED`
- `ETIMEDOUT`

### Testing
Updated `probing-caller` tests to align with timeout handling and verify timeout classification behavior.

[PIN-9334]: https://pagopa.atlassian.net/browse/PIN-9334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ