### PR TITLE
PIN-9133: make deleteEservice idempotent

### DIFF
--- a/packages/api-clients/open-api/probingEserviceOperationsApi.yaml
+++ b/packages/api-clients/open-api/probingEserviceOperationsApi.yaml
@@ -621,12 +621,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
-        "404":
-          description: The requested resource could not be found on the server
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Problem"
         "500":
           description: A managed error has occurred during the request elaboration
           content:

--- a/packages/probing-eservice-operations/src/routers/eserviceRouter.ts
+++ b/packages/probing-eservice-operations/src/routers/eserviceRouter.ts
@@ -105,7 +105,10 @@ const eServiceRouter = (
     )
     .delete("/eservices/:eserviceId/deleteEservice", async (req, res) => {
       try {
-        await eServiceService.deleteEservice(req.params.eserviceId);
+        await eServiceService.deleteEservice(
+          req.params.eserviceId,
+          logger(req.ctx),
+        );
 
         return res.status(204).end();
       } catch (error) {

--- a/packages/probing-eservice-operations/src/services/dbService.ts
+++ b/packages/probing-eservice-operations/src/services/dbService.ts
@@ -226,13 +226,16 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
       return data;
     },
 
-    async getEservicesById(eserviceId: string): Promise<EServiceSQL[]> {
-      const eservices = await db
+    async getEserviceById(
+      eserviceId: string,
+    ): Promise<EServiceSQL | undefined> {
+      const [eservice] = await db
         .select()
         .from(eservicesInProbing)
-        .where(and(eq(eservicesInProbing.eserviceId, eserviceId)));
+        .where(and(eq(eservicesInProbing.eserviceId, eserviceId)))
+        .limit(1);
 
-      return eservices;
+      return eservice;
     },
 
     async getEserviceByRecordId(

--- a/packages/probing-eservice-operations/src/services/dbService.ts
+++ b/packages/probing-eservice-operations/src/services/dbService.ts
@@ -134,10 +134,15 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
         });
     },
 
-    async deleteEservice(eserviceId: string): Promise<void> {
-      await db
+    async deleteEservice(
+      eserviceId: string,
+    ): Promise<{ id: number } | undefined> {
+      const [deletedEservice] = await db
         .delete(eservicesInProbing)
-        .where(eq(eservicesInProbing.eserviceId, eserviceId));
+        .where(eq(eservicesInProbing.eserviceId, eserviceId))
+        .returning({ id: eservicesInProbing.id });
+
+      return deletedEservice;
     },
 
     async saveTenant(tenantData: TenantSaveRequest): Promise<void> {
@@ -224,18 +229,6 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
         .limit(1);
 
       return data;
-    },
-
-    async getEserviceById(
-      eserviceId: string,
-    ): Promise<EServiceSQL | undefined> {
-      const [eservice] = await db
-        .select()
-        .from(eservicesInProbing)
-        .where(and(eq(eservicesInProbing.eserviceId, eserviceId)))
-        .limit(1);
-
-      return eservice;
     },
 
     async getEserviceByRecordId(

--- a/packages/probing-eservice-operations/src/services/eserviceService.ts
+++ b/packages/probing-eservice-operations/src/services/eserviceService.ts
@@ -99,15 +99,12 @@ export function eServiceServiceBuilder(dbService: DBService) {
       eserviceId: string,
       logger: Logger,
     ): Promise<probingEserviceOperationsApi.ApiDeleteEserviceResponse> {
-      const eService = await dbService.getEserviceById(eserviceId);
-      if (!eService) {
+      const deletedEservice = await dbService.deleteEservice(eserviceId);
+      if (!deletedEservice) {
         logger.error(
-          `EService with eserviceId ${eserviceId} not found while performing the delete operation. Operation skipped.`,
+          `EService with eserviceId ${eserviceId} not found during delete operation`,
         );
-        return;
       }
-
-      await dbService.deleteEservice(eserviceId);
     },
 
     async updateEserviceLastRequest(

--- a/packages/probing-eservice-operations/src/services/eserviceService.ts
+++ b/packages/probing-eservice-operations/src/services/eserviceService.ts
@@ -10,7 +10,6 @@ import {
 import {
   eServiceByRecordIdNotFound,
   eServiceByVersionIdNotFound,
-  eServiceNotFound,
 } from "../model/domain/errors.js";
 import { DBService } from "./dbService.js";
 import { z } from "zod";
@@ -98,10 +97,14 @@ export function eServiceServiceBuilder(dbService: DBService) {
 
     async deleteEservice(
       eserviceId: string,
+      logger: Logger,
     ): Promise<probingEserviceOperationsApi.ApiDeleteEserviceResponse> {
-      const eServices = await dbService.getEservicesById(eserviceId);
-      if (eServices.length === 0) {
-        throw eServiceNotFound(eserviceId);
+      const eService = await dbService.getEserviceById(eserviceId);
+      if (!eService) {
+        logger.error(
+          `EService with eserviceId ${eserviceId} not found while performing the delete operation. Operation skipped.`,
+        );
+        return;
       }
 
       await dbService.deleteEservice(eserviceId);

--- a/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
+++ b/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
@@ -24,7 +24,6 @@ import { eq, and } from "drizzle-orm";
 import {
   eServiceByRecordIdNotFound,
   eServiceByVersionIdNotFound,
-  eServiceNotFound,
   tenantNotFound,
 } from "../../src/model/domain/errors.js";
 import { v4 as uuidv4 } from "uuid";
@@ -584,7 +583,7 @@ describe("eService service", async () => {
       const eServiceRecordId = await addEservice(eService);
       const { eserviceId } = await getEservice(eServiceRecordId);
 
-      await eserviceService.deleteEservice(eserviceId);
+      await eserviceService.deleteEservice(eserviceId, genericLogger);
 
       const [result] = await db
         .select()
@@ -625,7 +624,7 @@ describe("eService service", async () => {
         .where(eq(eservicesInProbing.eserviceId, eServiceId));
       expect(beforeDelete.length).toBe(3);
 
-      await eserviceService.deleteEservice(eServiceId);
+      await eserviceService.deleteEservice(eServiceId, genericLogger);
 
       const afterDelete = await db
         .select()
@@ -644,7 +643,7 @@ describe("eService service", async () => {
         lastRequest: new Date().toISOString(),
       });
 
-      await eserviceService.deleteEservice(eserviceId);
+      await eserviceService.deleteEservice(eserviceId, genericLogger);
 
       const [result] = await db
         .select()
@@ -671,7 +670,7 @@ describe("eService service", async () => {
         status: "ok",
       });
 
-      await eserviceService.deleteEservice(eserviceId);
+      await eserviceService.deleteEservice(eserviceId, genericLogger);
 
       const [result] = await db
         .select()
@@ -682,12 +681,12 @@ describe("eService service", async () => {
       expect(result).toBeUndefined();
     });
 
-    it("should throw eServiceNotFound when attempting to delete a non-existent eService", async () => {
+    it("should not throw when attempting to delete a non-existent eService", async () => {
       const nonExistentId = uuidv4();
 
       await expect(
-        eserviceService.deleteEservice(nonExistentId),
-      ).rejects.toThrowError(eServiceNotFound(nonExistentId));
+        eserviceService.deleteEservice(nonExistentId, genericLogger),
+      ).resolves.not.toThrow();
     });
 
     it("should throw an error if the eserviceId param is invalid", async () => {
@@ -696,7 +695,10 @@ describe("eService service", async () => {
       };
 
       await expect(
-        eserviceService.deleteEservice(invalidEserviceParams.eserviceId),
+        eserviceService.deleteEservice(
+          invalidEserviceParams.eserviceId,
+          genericLogger,
+        ),
       ).rejects.toThrowError();
     });
   });

--- a/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
+++ b/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
@@ -686,7 +686,7 @@ describe("eService service", async () => {
 
       await expect(
         eserviceService.deleteEservice(nonExistentId, genericLogger),
-      ).resolves.not.toThrow();
+      ).resolves.toBeUndefined();
     });
 
     it("should throw an error if the eserviceId param is invalid", async () => {


### PR DESCRIPTION
## Jira Issue
[PIN-9133](https://pagopa.atlassian.net/browse/PIN-9133)

## Context/Why
`DELETE /eservices/{eserviceId}/deleteEservice` was returning `404` when the eService was already missing.  
That behavior caused repeated failures/retries on `EServiceDeleted` events.  
The endpoint is now idempotent: when the eService is not found, it logs an error and returns success (`204`) instead of throwing.

## Services Impacted
- probing-eservice-operations
- api-clients (OpenAPI spec)

## Key Changes
- Replaced `throw eServiceNotFound(...)` with `logger.error(...)` + skip in delete flow.
- Made logger mandatory in `deleteEservice` service method and passed it from router.
- Updated DB lookup to return a single element (`getEserviceById`) instead of an array.
- Removed `404` response from `DELETE /eservices/{eserviceId}/deleteEservice` in OpenAPI.
- Updated integration tests for the idempotent delete behavior.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] API and integration tests updated
- [x] OpenAPI spec updated

[PIN-9133]: https://pagopa.atlassian.net/browse/PIN-9133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ