### PR TITLE
PIN-9466: update JWT claims probing-caller

### DIFF
--- a/packages/probing-caller/.env
+++ b/packages/probing-caller/.env
@@ -1,9 +1,9 @@
 INTEROP_PROBING_CALLER_NAME="interop-be-probing-caller-test"
 LOG_LEVEL="info"
 
-SQS_ENDPOINT_POLL_QUEUE="http://localhost:9324/000000000000/poll"
-SQS_ENDPOINT_POLL_RESULT_QUEUE="http://localhost:9324/000000000000/update-response-received"
-SQS_ENDPOINT_TELEMETRY_RESULT_QUEUE="http://localhost:9324/000000000000/telemetry-result"
+SQS_ENDPOINT_POLL_QUEUE="http://elasticmq:9324/000000000000/poll"
+SQS_ENDPOINT_POLL_RESULT_QUEUE="http://elasticmq:9324/000000000000/update-response-received"
+SQS_ENDPOINT_TELEMETRY_RESULT_QUEUE="http://elasticmq:9324/000000000000/telemetry-result"
 SQS_LONG_POLL_WAIT_TIME_SECONDS="3"
 
 AWS_REGION="eu-south-1"

--- a/packages/probing-caller/.env
+++ b/packages/probing-caller/.env
@@ -1,14 +1,14 @@
 INTEROP_PROBING_CALLER_NAME="interop-be-probing-caller-test"
 LOG_LEVEL="info"
 
-SQS_ENDPOINT_POLL_QUEUE="http://elasticmq:9324/000000000000/poll"
-SQS_ENDPOINT_POLL_RESULT_QUEUE="http://elasticmq:9324/000000000000/update-response-received"
-SQS_ENDPOINT_TELEMETRY_RESULT_QUEUE="http://elasticmq:9324/000000000000/telemetry-result"
+SQS_ENDPOINT_POLL_QUEUE="http://localhost:9324/000000000000/poll"
+SQS_ENDPOINT_POLL_RESULT_QUEUE="http://localhost:9324/000000000000/update-response-received"
+SQS_ENDPOINT_TELEMETRY_RESULT_QUEUE="http://localhost:9324/000000000000/telemetry-result"
 SQS_LONG_POLL_WAIT_TIME_SECONDS="3"
+
 AWS_REGION="eu-south-1"
 AWS_CONFIG_FILE="aws.config.local"
 
 JWT_PAYLOAD_EXPIRE_TIME_IN_SEC="1"
 JWT_PAYLOAD_ISSUER="probing-caller-issuer"
-JWT_PAYLOAD_SUBJECT="probing-caller-subject"
 JWT_PAYLOAD_KID_KMS="81bdebb5-b810-4cac-bfc7-cae920b8abd1"

--- a/packages/probing-caller/src/utilities/config.ts
+++ b/packages/probing-caller/src/utilities/config.ts
@@ -18,7 +18,6 @@ const probingCallerConfig = AWSConfig.and(ConsumerConfig)
         LOG_LEVEL: z.string(),
         JWT_PAYLOAD_EXPIRE_TIME_IN_SEC: z.coerce.number().min(1),
         JWT_PAYLOAD_ISSUER: z.string(),
-        JWT_PAYLOAD_SUBJECT: z.string(),
         JWT_PAYLOAD_KID_KMS: z.string(),
         HTTP_REQUEST_TIMEOUT_MS: z.coerce.number().min(1).default(5000),
       })
@@ -31,7 +30,6 @@ const probingCallerConfig = AWSConfig.and(ConsumerConfig)
         logLevel: c.LOG_LEVEL,
         jwtPayloadExpireTimeInSec: c.JWT_PAYLOAD_EXPIRE_TIME_IN_SEC,
         jwtPayloadIssuer: c.JWT_PAYLOAD_ISSUER,
-        jwtPayloadSubject: c.JWT_PAYLOAD_SUBJECT,
         jwtPayloadKidKms: c.JWT_PAYLOAD_KID_KMS,
         httpRequestTimeoutMs: c.HTTP_REQUEST_TIMEOUT_MS,
       })),

--- a/packages/probing-caller/src/utilities/kmsClientHandler.ts
+++ b/packages/probing-caller/src/utilities/kmsClientHandler.ts
@@ -12,8 +12,6 @@ import { buildJWTError } from "../model/domain/errors.js";
 
 interface Claims {
   aud: string[];
-  sub: string;
-  nbf: number;
   iss: string;
   exp: number;
   iat: number;
@@ -74,8 +72,6 @@ function createPayload(audience: string[]): string {
 
   const claims: Claims = {
     aud: audience,
-    sub: config.jwtPayloadSubject,
-    nbf: currentTimeInSeconds,
     iss: config.jwtPayloadIssuer,
     exp: currentTimeInSeconds + config.jwtPayloadExpireTimeInSec,
     iat: currentTimeInSeconds,


### PR DESCRIPTION
## Jira Issue
[PIN-9466](https://pagopa.atlassian.net/browse/PIN-9466)

## Context/Why
- Remove `sub` and `nbf` claims from the JWT used to authorize e-service health-check calls

## Services Impacted
- probing-caller

## Key Changes
- Drop `sub` and `nbf` from JWT payload in `kmsClientHandler`
- Remove `JWT_PAYLOAD_SUBJECT` from config

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard

[PIN-9466]: https://pagopa.atlassian.net/browse/PIN-9466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ