### PR TITLE
fix: back button on monitoring detail page (PIN-9470)

### DIFF
--- a/packages/probing-frontend/src/pages/MonitoringDetailPage/components/charts/ChartWrapper.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringDetailPage/components/charts/ChartWrapper.tsx
@@ -58,10 +58,10 @@ export const ChartWrapper: React.FC<ChartWrapperProps> = ({ eserviceId, pollingF
     const endMissing = !endDate || endDate === ''
 
     if (startMissing || endMissing) {
-      setSearchParams({
+      setSearchParams({ 
         startDate: last24h.toISOString(),
-        endDate: now.toISOString(),
-      })
+        endDate: now.toISOString()
+      }, { replace: true })
       return
     }
 
@@ -79,7 +79,7 @@ export const ChartWrapper: React.FC<ChartWrapperProps> = ({ eserviceId, pollingF
       setSearchParams({
         startDate: last24h.toISOString(),
         endDate: now.toISOString(),
-      })
+      }, { replace: true })
     }
   }, [startDate, endDate, setSearchParams])
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-9470](https://pagopa.atlassian.net/browse/PIN-9470)

## 📝 Description / Context
If you navigate from the listing page to the individual e-service's page and go back, nothing happens. The same goes for other page changes.

## 🛠 List of changes
- Fixed the setSearchParams to replace the url in navigation history in ChartWrapper.tsx component

## 🧪 How to test

1. Click on "Read more" on one e-service
2. Press the browser back button

[PIN-9470]: https://pagopa.atlassian.net/browse/PIN-9470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ