### PR TITLE
fix: aligned index meta tags (PIN-9468)

### DIFF
--- a/packages/probing-frontend/index.html
+++ b/packages/probing-frontend/index.html
@@ -1,9 +1,16 @@
 <!doctype html>
 <html lang="it">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    
+    <title>Monitoraggio e-service | PDND Interoperabilità | PagoPA</title>
+    <meta
+      name="description"
+      content="Il servizio di monitoraggio che verifica la disponibilità e lo stato degli e-service presenti sulla Piattaforma Digitale Nazionale Dati (PDND)."
+    />
+    <meta name="theme-color" content="#00a1b0" />
     <link rel="manifest" href="./manifest.webmanifest" crossorigin="anonymous" />
     <link rel="icon" href="./favicon-32x32.png" type="image/png" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
@@ -15,8 +22,6 @@
     <link rel="apple-touch-icon" sizes="256x256" href="./icons/icon-256x256.png" />
     <link rel="apple-touch-icon" sizes="384x384" href="./icons/icon-384x384.png" />
     <link rel="apple-touch-icon" sizes="512x512" href="./icons/icon-512x512.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Monitoraggio e-service | PDND Interoperabilità | PagoPA</title>
   </head>
   <body>
     <noscript>Abilita JavaScript per utilizzare quest'applicazione</noscript>


### PR DESCRIPTION
## 🔗 Issue
[PIN-9468](https://pagopa.atlassian.net/browse/PIN-9468)

## 📝 Description / Context
The index.html <meta> tags are not aligned to the PDND ones 

## 🛠 List of changes
- Changed index.html <meta> tags

[PIN-9468]: https://pagopa.atlassian.net/browse/PIN-9468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ