### PR TITLE
fix: changed link to button on monitoring detail page (PIN-9472)

### DIFF
--- a/packages/probing-frontend/src/pages/MonitoringDetailPage/MonitoringDetail.page.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringDetailPage/MonitoringDetail.page.tsx
@@ -1,5 +1,5 @@
 import { MonitoringQueries } from '@/api/monitoring/monitoring.hooks'
-import { Link, useParams } from '@/router'
+import { useParams } from '@/router'
 import { MonitoringEserviceTelemetry } from './components/MonitoringEserviceTelemetry'
 import {
   MonitoringEserviceProbing,
@@ -13,7 +13,7 @@ import { Box, Stack } from '@mui/system'
 import { useTranslation } from 'react-i18next'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { PageContainer } from '@/components/layout/PageContainer'
-import { Skeleton } from '@mui/material'
+import { Button, Skeleton } from '@mui/material'
 import { useHandleRefetch } from '@/hooks/useRefetch'
 import type { ProbingEservice } from '@/api/monitoring/monitoring.models'
 import { ChartWrapperSkeleton } from './components/charts/ChartWrapper'
@@ -68,14 +68,13 @@ export const MonitoringDetailPage: React.FC = () => {
           />
         )}
         <Stack alignItems="center" sx={{ mt: 8 }}>
-          <Link
-            to={'MONITORING_E_SERVICE_LIST'}
-            as="button"
+          <Button
             variant="naked"
             startIcon={<ArrowBackIcon />}
+            onClick={() => window.history.back()}
           >
             {t('returnToList')}
-          </Link>
+          </Button>
         </Stack>
       </Box>
     </PageContainer>
@@ -84,38 +83,36 @@ export const MonitoringDetailPage: React.FC = () => {
 
 const DetailPageSkeleton: React.FC = () => {
   return (
-    <>
-      <PageContainer isLoading>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <MonitoringEserviceDetailSkeleton />
-        </Box>
-        <Box
-          sx={{
-            mt: 5,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <Skeleton width={'300px'} height={40} sx={{ mb: 2 }} />
-          <MonitoringEserviceProbingSkeleton />
-        </Box>
-        <Stack sx={{ mt: 30, pb: 4, textAlign: 'center', alignItems: 'center' }}>
-          <Skeleton sx={{ height: '60px', width: '400px' }} />
-        </Stack>
-        <ChartWrapperSkeleton />
-        <Stack alignItems="center" sx={{ mt: 10 }}>
-          <Skeleton sx={{ height: '30px', width: '200px' }} />
-        </Stack>
-      </PageContainer>
-    </>
+    <PageContainer isLoading>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <MonitoringEserviceDetailSkeleton />
+      </Box>
+      <Box
+        sx={{
+          mt: 5,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Skeleton width={'300px'} height={40} sx={{ mb: 2 }} />
+        <MonitoringEserviceProbingSkeleton />
+      </Box>
+      <Stack sx={{ mt: 30, pb: 4, textAlign: 'center', alignItems: 'center' }}>
+        <Skeleton sx={{ height: '60px', width: '400px' }} />
+      </Stack>
+      <ChartWrapperSkeleton />
+      <Stack alignItems="center" sx={{ mt: 10 }}>
+        <Skeleton sx={{ height: '30px', width: '200px' }} />
+      </Stack>
+    </PageContainer>
   )
 }


### PR DESCRIPTION
## 🔗 Issue
[PIN-9472](https://pagopa.atlassian.net/browse/PIN-9472)

## 📝 Description / Context
The "Return to e-service list" button does not maintains query params 

## 🛠 List of changes
- Changed <Link> to <Button> on MonitoringDetail.page.tsx
- Triggered window.history.back() instead of navigate to route

## 🧪 How to test

1. Apply filters in the e-service monitoring page
2. Click on "Read more" on one e-service
3. Press the browser back button
4. Check if the filters are still set

[PIN-9472]: https://pagopa.atlassian.net/browse/PIN-9472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ