### PR TITLE
fix: changed eservice status label, added tooltips (PIN-9505)

### DIFF
--- a/packages/probing-frontend/src/locales/en/common.json
+++ b/packages/probing-frontend/src/locales/en/common.json
@@ -113,6 +113,20 @@
     "noDataLabel": "No results",
     "loading": "Loading..."
   },
+  "state": {
+    "available": {
+      "label": "Available",
+      "tooltip": "The API for this e-service is responding correctly."
+    },
+    "unavailable": {
+      "label": "Not responding",
+      "tooltip": "The API for this e-service is currently unavailable."
+    },
+    "unverified": {
+      "label": "Verification failed",
+      "tooltip": "We were never able to contact the API for this e-service."
+    }
+  },
   "detailsPage": {
     "titleOperativita": "Operativity",
     "historyTitle": "History monitoring",

--- a/packages/probing-frontend/src/locales/it/common.json
+++ b/packages/probing-frontend/src/locales/it/common.json
@@ -112,6 +112,20 @@
     "noDataLabel": "La ricerca non ha prodotto risultati",
     "loading": "Operazione in corso..."
   },
+  "state": {
+    "available": {
+      "label": "Disponibile",
+      "tooltip": "L'API di questo e-service risponde correttamente"
+    },
+    "unavailable": {
+      "label": "Non risponde",
+      "tooltip": "L'API di questo e-service non è raggiungibile al momento"
+    },
+    "unverified": {
+      "label": "Verifica non riuscita",
+      "tooltip": "Non siamo mai riusciti a contattare l'API di questo e-service"
+    }
+  },
   "detailsPage": {
     "titleOperativita": "Operatività",
     "historyTitle": "Storico del monitoraggio",

--- a/packages/probing-frontend/src/pages/MonitoringDetailPage/components/MonitoringEserviceProbing.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringDetailPage/components/MonitoringEserviceProbing.tsx
@@ -1,13 +1,11 @@
-import type {
-  ProbingEServiceMonitorState,
-  ProbingEservice,
-} from '@/api/monitoring/monitoring.models'
-import { Alert, Box, Chip, Grid, Skeleton, Stack, Typography } from '@mui/material'
+import type { ProbingEservice } from '@/api/monitoring/monitoring.models'
+import { Alert, Box, Chip, Grid, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
 import { ButtonNaked } from '@pagopa/mui-italia'
 import { useTranslation } from 'react-i18next'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import { formatDateString } from '@/utils/date.utils'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { EserviceState, eserviceStateConfig } from '@/types/eservice-state.types'
 
 type MonitoringEserviceProbingProps = {
   eservicesProbingDetail: ProbingEservice
@@ -24,17 +22,9 @@ export const MonitoringEserviceProbing: React.FC<MonitoringEserviceProbingProps>
   const { t } = useTranslation('common', {
     keyPrefix: 'detailsPage',
   })
+  const { t: tCommon } = useTranslation('common')
 
-  const getProbingStateChipColor = (value: ProbingEServiceMonitorState) => {
-    switch (value) {
-      case 'ONLINE':
-        return 'success'
-      case 'OFFLINE':
-        return 'error'
-      case 'N_D':
-        return 'warning'
-    }
-  }
+  const config = eserviceStateConfig[eservicesProbingDetail.state as EserviceState] ?? eserviceStateConfig.N_D
 
   return (
     <Box sx={{ mt: '40px', width: '100%', minWidth: '400px', maxWidth: '600px' }}>
@@ -60,15 +50,13 @@ export const MonitoringEserviceProbing: React.FC<MonitoringEserviceProbingProps>
         <InformationContainer
           label={t('eserviceState')}
           content={
-            <Chip
-              size={'small'}
-              label={
-                eservicesProbingDetail.state === 'N_D'
-                  ? 'n/d'
-                  : eservicesProbingDetail.state.toLowerCase()
-              }
-              color={getProbingStateChipColor(eservicesProbingDetail.state)}
-            />
+            <Tooltip title={tCommon(config.tooltipKey)}>
+              <Chip
+                size={'small'}
+                label={tCommon(config.labelKey)}
+                color={config.color}
+              />
+            </Tooltip>
           }
         />
         <InformationContainer

--- a/packages/probing-frontend/src/pages/MonitoringEServicesListPage/components/MonitoringTable.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringEServicesListPage/components/MonitoringTable.tsx
@@ -16,6 +16,7 @@ import type { TFunction } from 'i18next'
 import React from 'react'
 import type { EService } from '@/api/monitoring/monitoring.models'
 import { useHandleRefetch } from '@/hooks/useRefetch'
+import { eserviceStateConfig } from '@/types/eservice-state.types'
 
 const headLabels = (t: TFunction<'common', 'table'>): Array<string> => {
   return [
@@ -30,6 +31,7 @@ const headLabels = (t: TFunction<'common', 'table'>): Array<string> => {
 
 export const MonitoringTable: React.FC = () => {
   const { t } = useTranslation('common', { keyPrefix: 'table' })
+  const { t: tCommon } = useTranslation('common')
   const [totalEServices, setTotalEServices] = React.useState<number | undefined>()
   const { paginationParams, paginationProps, getTotalPageCount } = usePagination({ limit: 10 })
   const [producersAutocompleteTextInput, setProducersAutocompleteTextInput] =
@@ -65,9 +67,9 @@ export const MonitoringTable: React.FC = () => {
       type: 'autocomplete-multiple',
       label: t('serviceStateFilter'),
       options: [
-        { value: 'ONLINE', label: 'online' },
-        { value: 'OFFLINE', label: 'offline' },
-        { value: 'N_D', label: 'n/d' },
+        { value: 'ONLINE', label: tCommon(eserviceStateConfig.ONLINE.labelKey) },
+        { value: 'OFFLINE', label: tCommon(eserviceStateConfig.OFFLINE.labelKey) },
+        { value: 'N_D', label: tCommon(eserviceStateConfig.N_D.labelKey) },
       ],
     },
   ])
@@ -117,7 +119,7 @@ export const MonitoringTable: React.FC = () => {
         </Table>
       )}
 
-  <Pagination {...paginationProps} totalPages={getTotalPageCount(totalEServices)} />
+      <Pagination {...paginationProps} totalPages={getTotalPageCount(totalEServices)} />
     </>
   )
 }

--- a/packages/probing-frontend/src/pages/MonitoringEServicesListPage/components/MonitoringTableRow.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringEServicesListPage/components/MonitoringTableRow.tsx
@@ -1,17 +1,21 @@
 import { TableRow } from '@pagopa/interop-fe-commons'
-import { Chip } from '@mui/material'
+import { Chip, Tooltip } from '@mui/material'
 import { formatDateString } from '@/utils/date.utils'
 import { useTranslation } from 'react-i18next'
 import type { EserviceContent } from '../../../api/monitoring/monitoring.models'
 import { ButtonNaked } from '@pagopa/mui-italia'
 import { useNavigate } from '@/router'
 import React from 'react'
+import { EserviceState, eserviceStateConfig } from '@/types/eservice-state.types'
 
 type MonitoringTableRowProps = { row: EserviceContent }
 
 export const MonitoringTableRow: React.FC<MonitoringTableRowProps> = ({ row }) => {
   const { t } = useTranslation('common')
   const navigate = useNavigate()
+
+  const config = eserviceStateConfig[row.state as EserviceState] ?? eserviceStateConfig.N_D
+
   return (
     <>
       <TableRow
@@ -19,14 +23,13 @@ export const MonitoringTableRow: React.FC<MonitoringTableRowProps> = ({ row }) =
           row.eserviceName,
           row.versionNumber.toString(),
           row.producerName,
-          <Chip
-            key={row.eserviceRecordId}
-            label={row.state === 'N_D' ? 'n/d' : row.state.toLowerCase()}
-            size="small"
-            color={
-              row.state === 'ONLINE' ? 'success' : row.state === 'OFFLINE' ? 'error' : 'warning'
-            }
-          />,
+          <Tooltip key={row.eserviceRecordId} title={t(config.tooltipKey)}>
+            <Chip
+              label={t(config.labelKey)}
+              size="small"
+              color={config.color}
+            />
+          </Tooltip>,
           row.responseReceived ? formatDateString(row.responseReceived) : 'n/a',
           <ButtonNaked
             key={row.eserviceRecordId}

--- a/packages/probing-frontend/src/types/eservice-state.types.ts
+++ b/packages/probing-frontend/src/types/eservice-state.types.ts
@@ -1,0 +1,19 @@
+export const eserviceStateConfig = {
+    ONLINE: {
+        labelKey: 'state.available.label',
+        tooltipKey: 'state.available.tooltip',
+        color: 'success',
+    },
+    OFFLINE: {
+        labelKey: 'state.unavailable.label',
+        tooltipKey: 'state.unavailable.tooltip',
+        color: 'error',
+    },
+    N_D: {
+        labelKey: 'state.unverified.label',
+        tooltipKey: 'state.unverified.tooltip',
+        color: 'warning',
+    },
+} as const
+  
+export type EserviceState = keyof typeof eserviceStateConfig


### PR DESCRIPTION
## 🔗 Issue
[PIN-9505](https://pagopa.atlassian.net/browse/PIN-9505)

## 📝 Description / Context
The e-service status chips label need to be changed and tooltips need to be added

## 🛠 List of changes
- Changed translations
- Added tooltips

## 🧪 How to test

1. Filter e-services by status
2. Hover with the mouse on e-service status chip
3. Check if the tooltips have the correct text 
4. Navigate to e-service status detail
5. Repeat step 3

[PIN-9505]: https://pagopa.atlassian.net/browse/PIN-9505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ