### PR TITLE
fix: monitoring table scroll on top when paginating (PIN-9469)

### DIFF
--- a/packages/probing-frontend/src/pages/MonitoringEServicesListPage/components/MonitoringTable.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringEServicesListPage/components/MonitoringTable.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import { MonitoringTableRow } from './MonitoringTableRow'
 import { MonitoringQueries } from '@/api/monitoring/monitoring.hooks'
-import { Skeleton } from '@mui/material'
+import { Box, Skeleton } from '@mui/material'
 import type { TFunction } from 'i18next'
 import React from 'react'
 import type { EService } from '@/api/monitoring/monitoring.models'
@@ -78,6 +78,7 @@ export const MonitoringTable: React.FC = () => {
   }
 
   const { data: eservices, refetch, isLoading } = MonitoringQueries.useGetList(params)
+  const scrollRef = React.useRef<HTMLDivElement | null>(null)
 
   React.useEffect(() => {
     if (eservices?.totalElements !== undefined) {
@@ -85,10 +86,14 @@ export const MonitoringTable: React.FC = () => {
     }
   }, [eservices?.totalElements])
 
+  React.useEffect(() => {
+    scrollRef?.current?.scrollIntoView({ behavior: 'auto' })
+  }, [paginationParams.offset])
+
   const handleRefetch = useHandleRefetch<EService>(refetch)
 
   return (
-    <>
+    <Box ref={scrollRef}>
       <Filters
         {...handlers}
         rightContent={
@@ -117,8 +122,8 @@ export const MonitoringTable: React.FC = () => {
         </Table>
       )}
 
-  <Pagination {...paginationProps} totalPages={getTotalPageCount(totalEServices)} />
-    </>
+      <Pagination {...paginationProps} totalPages={getTotalPageCount(totalEServices)} />
+    </Box>
   )
 }
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-9469](https://pagopa.atlassian.net/browse/PIN-9469)

## 📝 Description / Context
When the pagination on the e-services monitoring table changes, the window should scroll to the top of the table

## 🛠 List of changes
- Added scrollRef to the Box element
- Added useEffect to listen to pagination changes and trigger the scroll to the scrollRef

## 🧪 How to test

1. Scroll down to the pagination on the e-service monitoring table
2. Change pagination to page 2
3. Check if the scroll to top occurs

[PIN-9469]: https://pagopa.atlassian.net/browse/PIN-9469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ