### PR TITLE
chore: added eservice detail id, removed link to catalog (PIN-9595)

### DIFF
--- a/packages/probing-frontend/src/locales/en/common.json
+++ b/packages/probing-frontend/src/locales/en/common.json
@@ -138,6 +138,8 @@
     "loading": "Loading...",
     "startDateTime": "Period start date and time",
     "endDateTime": "Period end date and time",
+    "eserviceID": "E-SERVICE ID",
+    "copySuccessFeedbackText": "ID successfully copied",
     "alerts": {
       "monitoringSuspended": "Monitoring suspended",
       "versionSuspendedMessage": "The e-service is offline because this version is currently suspended",

--- a/packages/probing-frontend/src/locales/it/common.json
+++ b/packages/probing-frontend/src/locales/it/common.json
@@ -137,6 +137,8 @@
     "loading": "Operazione in corso...",
     "startDateTime": "Data e ora inizio periodo",
     "endDateTime": "Data e ora fine periodo",
+    "eserviceID": "ID E-SERVICE",
+    "copySuccessFeedbackText": "ID copiato correttamente",
     "alerts": {
       "monitoringSuspended": "Monitoraggio sospeso",
       "versionSuspendedMessage": "L'e-service è offline perché questa versione è attualmente sospesa",

--- a/packages/probing-frontend/src/pages/MonitoringDetailPage/components/MonitoringEserviceDetail.tsx
+++ b/packages/probing-frontend/src/pages/MonitoringDetailPage/components/MonitoringEserviceDetail.tsx
@@ -1,11 +1,7 @@
 import type { MainEservice } from '@/api/monitoring/monitoring.models'
 import { Skeleton, Stack } from '@mui/material'
-import { ButtonNaked } from '@pagopa/mui-italia'
+import { CopyToClipboardButton } from '@pagopa/mui-italia'
 import { useTranslation } from 'react-i18next'
-import LaunchIcon from '@mui/icons-material/Launch'
-import LockIcon from '@mui/icons-material/Lock'
-import { Link } from 'react-router-dom'
-import { CATALOGUE_BASE_PATH } from '@/config/constants'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 
 type MonitoringEserviceDetailProps = {
@@ -19,10 +15,6 @@ export const MonitoringEserviceDetail: React.FC<MonitoringEserviceDetailProps> =
     keyPrefix: 'detailsPage',
   })
 
-  const getExternalCatalogUrl = () => {
-    return `${CATALOGUE_BASE_PATH}/ui/it/catalogo-e-service/${eservicesDetail.eserviceId}/${eservicesDetail.versionId}`
-  }
-
   return (
     <Stack spacing={3} sx={{ width: '100%', minWidth: '400px', maxWidth: '600px' }}>
       <InformationContainer label={t('producerName')} content={eservicesDetail.producerName} />
@@ -31,19 +23,18 @@ export const MonitoringEserviceDetail: React.FC<MonitoringEserviceDetailProps> =
         content={eservicesDetail.versionNumber.toString()}
       />
       <InformationContainer
-        label={t('eServiceTab')}
+        label={t('eserviceID')}
+        sx={{alignItems: 'center'}}
         content={
-          <ButtonNaked
-            color="primary"
-            size="small"
-            startIcon={<LockIcon />}
-            endIcon={<LaunchIcon />}
-            component={Link}
-            target="_blank"
-            to={getExternalCatalogUrl()}
-          >
-            {t('viewInCatalog')}
-          </ButtonNaked>
+          <>
+            {eservicesDetail.eserviceId}
+            <CopyToClipboardButton
+              size='small'
+              color="primary"
+              value={eservicesDetail.eserviceId}
+              tooltipTitle={t('copySuccessFeedbackText')}
+            />
+          </>
         }
       />
     </Stack>


### PR DESCRIPTION
## Issue
- [PIN-9595](https://pagopa.atlassian.net/browse/PIN-9595)
## Description / Context / Why
- Removed link to catalog on e-service monitoring page
- Added e-service id with copy to clipboard button

[PIN-9595]: https://pagopa.atlassian.net/browse/PIN-9595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ