### PR TITLE
chore: added vite proxy configuration (PIN-9615)

### DIFF
--- a/packages/probing-frontend/vite.config.ts
+++ b/packages/probing-frontend/vite.config.ts
@@ -13,9 +13,14 @@ export default defineConfig({
   server: {
     proxy: {
       '/eservices': {
-      target: 'https://dev.stato-eservice.interop.pagopa.it',
-      changeOrigin: true,
-      secure: false,
+        target: 'https://dev.stato-eservice.interop.pagopa.it',
+        changeOrigin: true,
+        secure: false,
+      },
+      '/producers': {
+        target: 'https://dev.stato-eservice.interop.pagopa.it',
+        changeOrigin: true,
+        secure: false,
       },
     },
   },

--- a/packages/probing-frontend/vite.config.ts
+++ b/packages/probing-frontend/vite.config.ts
@@ -12,12 +12,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/eservices': {
-        target: 'https://dev.stato-eservice.interop.pagopa.it',
-        changeOrigin: true,
-        secure: false,
-      },
-      '/producers': {
+      '^/(eservices|producers)': {
         target: 'https://dev.stato-eservice.interop.pagopa.it',
         changeOrigin: true,
         secure: false,

--- a/packages/probing-frontend/vite.config.ts
+++ b/packages/probing-frontend/vite.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
       '@/': `${path.resolve(__dirname, 'src')}/`,
     },
   },
+  server: {
+    proxy: {
+      '/eservices': {
+      target: 'https://dev.stato-eservice.interop.pagopa.it',
+      changeOrigin: true,
+      secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 🔗 Issue
[PIN-9615](https://pagopa.atlassian.net/browse/PIN-9615)

## 📝 Description / Context
When launching the application in a local environment, it does not reach the develop backend's endpoints, unless a proxy is added

## 🛠 List of changes
- Added a proxy rule to `packages/probing-frontend/vite.config.ts`

[PIN-9615]: https://pagopa.atlassian.net/browse/PIN-9615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ