### PR TITLE
chore: hidden login button (PIN-9735)

### DIFF
--- a/packages/probing-frontend/src/components/layout/Header.tsx
+++ b/packages/probing-frontend/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ export const Header: React.FC = () => {
         loggedUser={jwt ? { id: jwt.email } : false}
         onLogin={() => handleLogin()}
         onLogout={() => handleLogout()}
+        enableLogin={false}
         onAssistanceClick={() => {
           window.open(assistanceLink, '_blank')
         }}


### PR DESCRIPTION
## Issue
- [PIN-9735](https://pagopa.atlassian.net/browse/PIN-9735)
## Description / Context / Why
- Hidden login button by setting enableLogin to false on <HeaderAccount> component

[PIN-9735]: https://pagopa.atlassian.net/browse/PIN-9735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ