### PR TITLE
feature(PIN-9734): tenants allow list

### DIFF
--- a/docker/postgres/init-db.sql
+++ b/docker/postgres/init-db.sql
@@ -5,15 +5,18 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- Tables
 CREATE TABLE IF NOT EXISTS probing.tenants (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    tenant_id UUID NOT NULL UNIQUE,
+    tenant_id VARCHAR(36) NOT NULL UNIQUE,
     tenant_name VARCHAR(2048)
 );
 
+CREATE TABLE IF NOT EXISTS probing.tenants_allow_list (tenant_id VARCHAR(36) PRIMARY KEY);
+
 CREATE TABLE IF NOT EXISTS probing.eservices (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    eservice_id UUID NOT NULL,
-    version_id UUID NOT NULL,
+    eservice_id VARCHAR(36) NOT NULL,
+    version_id VARCHAR(36) NOT NULL,
     eservice_name VARCHAR(255) NOT NULL,
+    producer_id VARCHAR(36),
     producer_name VARCHAR(2048) NOT NULL,
     eservice_technology VARCHAR(255) NOT NULL,
     base_path VARCHAR(2048) [] NOT NULL,
@@ -46,6 +49,7 @@ SELECT
     e.id,
     e.eservice_id,
     e.eservice_name,
+    e.producer_id,
     e.producer_name,
     e.version_id,
     e.state,
@@ -71,6 +75,8 @@ CREATE INDEX IF NOT EXISTS eservices_producer_upper_trgm_idx ON probing.eservice
 CREATE INDEX IF NOT EXISTS eservices_name_upper_trgm_idx ON probing.eservices USING GIN ((UPPER(eservice_name)) gin_trgm_ops);
 
 CREATE INDEX IF NOT EXISTS eservices_state_idx ON probing.eservices (state);
+
+CREATE INDEX IF NOT EXISTS eservices_producer_id_idx ON probing.eservices (producer_id);
 
 CREATE INDEX IF NOT EXISTS eservices_polling_ready_idx ON probing.eservices (
     state,

--- a/docker/postgres/init-db.sql
+++ b/docker/postgres/init-db.sql
@@ -9,7 +9,9 @@ CREATE TABLE IF NOT EXISTS probing.tenants (
     tenant_name VARCHAR(2048)
 );
 
-CREATE TABLE IF NOT EXISTS probing.tenants_allow_list (tenant_id UUID PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS probing.tenants_allow_list (
+    tenant_id UUID PRIMARY KEY REFERENCES probing.tenants(tenant_id) ON DELETE RESTRICT
+);
 
 CREATE TABLE IF NOT EXISTS probing.eservices (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/docker/postgres/init-db.sql
+++ b/docker/postgres/init-db.sql
@@ -5,18 +5,18 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- Tables
 CREATE TABLE IF NOT EXISTS probing.tenants (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    tenant_id VARCHAR(36) NOT NULL UNIQUE,
+    tenant_id UUID NOT NULL UNIQUE,
     tenant_name VARCHAR(2048)
 );
 
-CREATE TABLE IF NOT EXISTS probing.tenants_allow_list (tenant_id VARCHAR(36) PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS probing.tenants_allow_list (tenant_id UUID PRIMARY KEY);
 
 CREATE TABLE IF NOT EXISTS probing.eservices (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    eservice_id VARCHAR(36) NOT NULL,
-    version_id VARCHAR(36) NOT NULL,
+    eservice_id UUID NOT NULL,
+    version_id UUID NOT NULL,
     eservice_name VARCHAR(255) NOT NULL,
-    producer_id VARCHAR(36),
+    producer_id UUID,
     producer_name VARCHAR(2048) NOT NULL,
     eservice_technology VARCHAR(255) NOT NULL,
     base_path VARCHAR(2048) [] NOT NULL,

--- a/packages/probing-eservice-operations/src/db/drizzle/schema.ts
+++ b/packages/probing-eservice-operations/src/db/drizzle/schema.ts
@@ -1,7 +1,6 @@
 import {
   pgSchema,
   unique,
-  uuid,
   varchar,
   integer,
   boolean,
@@ -19,19 +18,24 @@ export const tenantsInProbing = probing.table(
   "tenants",
   {
     id: bigint({ mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    tenantId: uuid("tenant_id").notNull(),
+    tenantId: varchar("tenant_id", { length: 36 }).notNull(),
     tenantName: varchar("tenant_name", { length: 2048 }),
   },
   (table) => [unique("tenants_tenant_id_key").on(table.tenantId)],
 );
 
+export const tenantsAllowListInProbing = probing.table("tenants_allow_list", {
+  tenantId: varchar("tenant_id", { length: 36 }).primaryKey(),
+});
+
 export const eservicesInProbing = probing.table(
   "eservices",
   {
     id: bigint({ mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    eserviceId: uuid("eservice_id").notNull(),
-    versionId: uuid("version_id").notNull(),
+    eserviceId: varchar("eservice_id", { length: 36 }).notNull(),
+    versionId: varchar("version_id", { length: 36 }).notNull(),
     eserviceName: varchar("eservice_name", { length: 255 }).notNull(),
+    producerId: varchar("producer_id", { length: 36 }),
     producerName: varchar("producer_name", { length: 2048 }).notNull(),
     eserviceTechnology: varchar("eservice_technology", {
       length: 255,
@@ -99,10 +103,11 @@ export const eserviceProbingResponsesInProbing = probing.table(
 export const eserviceViewInProbing = probing
   .view("eservice_view", {
     id: bigint({ mode: "number" }),
-    eserviceId: uuid("eservice_id"),
+    eserviceId: varchar("eservice_id", { length: 36 }),
     eserviceName: varchar("eservice_name", { length: 255 }),
+    producerId: varchar("producer_id", { length: 36 }),
     producerName: varchar("producer_name", { length: 2048 }),
-    versionId: uuid("version_id"),
+    versionId: varchar("version_id", { length: 36 }),
     state: varchar({ length: 255 }),
     status: varchar({ length: 2 }),
     probingEnabled: boolean("probing_enabled"),
@@ -123,7 +128,7 @@ export const eserviceViewInProbing = probing
     audience: varchar({ length: 2048 }),
   })
   .as(
-    sql`SELECT e.id, e.eservice_id, e.eservice_name, e.producer_name, e.version_id, e.state, epr.status, e.probing_enabled, e.version_number, epr.response_received, epreq.last_request, e.polling_frequency, e.polling_start_time, e.polling_end_time, e.base_path, e.eservice_technology, e.audience
+    sql`SELECT e.id, e.eservice_id, e.eservice_name, e.producer_id, e.producer_name, e.version_id, e.state, epr.status, e.probing_enabled, e.version_number, epr.response_received, epreq.last_request, e.polling_frequency, e.polling_start_time, e.polling_end_time, e.base_path, e.eservice_technology, e.audience
       FROM ${config.dbSchema}.eservices e
       LEFT JOIN ${config.dbSchema}.eservice_probing_responses epr ON epr.eservices_record_id = e.id
       LEFT JOIN ${config.dbSchema}.eservice_probing_requests epreq ON epreq.eservices_record_id = e.id`,

--- a/packages/probing-eservice-operations/src/db/drizzle/schema.ts
+++ b/packages/probing-eservice-operations/src/db/drizzle/schema.ts
@@ -25,9 +25,19 @@ export const tenantsInProbing = probing.table(
   (table) => [unique("tenants_tenant_id_key").on(table.tenantId)],
 );
 
-export const tenantsAllowListInProbing = probing.table("tenants_allow_list", {
-  tenantId: uuid("tenant_id").primaryKey(),
-});
+export const tenantsAllowListInProbing = probing.table(
+  "tenants_allow_list",
+  {
+    tenantId: uuid("tenant_id").primaryKey(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.tenantId],
+      foreignColumns: [tenantsInProbing.tenantId],
+      name: "tenants_allow_list_tenant_id_fkey",
+    }).onDelete("restrict"),
+  ],
+);
 
 export const eservicesInProbing = probing.table(
   "eservices",

--- a/packages/probing-eservice-operations/src/db/drizzle/schema.ts
+++ b/packages/probing-eservice-operations/src/db/drizzle/schema.ts
@@ -1,6 +1,7 @@
 import {
   pgSchema,
   unique,
+  uuid,
   varchar,
   integer,
   boolean,
@@ -18,24 +19,24 @@ export const tenantsInProbing = probing.table(
   "tenants",
   {
     id: bigint({ mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    tenantId: varchar("tenant_id", { length: 36 }).notNull(),
+    tenantId: uuid("tenant_id").notNull(),
     tenantName: varchar("tenant_name", { length: 2048 }),
   },
   (table) => [unique("tenants_tenant_id_key").on(table.tenantId)],
 );
 
 export const tenantsAllowListInProbing = probing.table("tenants_allow_list", {
-  tenantId: varchar("tenant_id", { length: 36 }).primaryKey(),
+  tenantId: uuid("tenant_id").primaryKey(),
 });
 
 export const eservicesInProbing = probing.table(
   "eservices",
   {
     id: bigint({ mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    eserviceId: varchar("eservice_id", { length: 36 }).notNull(),
-    versionId: varchar("version_id", { length: 36 }).notNull(),
+    eserviceId: uuid("eservice_id").notNull(),
+    versionId: uuid("version_id").notNull(),
     eserviceName: varchar("eservice_name", { length: 255 }).notNull(),
-    producerId: varchar("producer_id", { length: 36 }),
+    producerId: uuid("producer_id"),
     producerName: varchar("producer_name", { length: 2048 }).notNull(),
     eserviceTechnology: varchar("eservice_technology", {
       length: 255,
@@ -103,11 +104,11 @@ export const eserviceProbingResponsesInProbing = probing.table(
 export const eserviceViewInProbing = probing
   .view("eservice_view", {
     id: bigint({ mode: "number" }),
-    eserviceId: varchar("eservice_id", { length: 36 }),
+    eserviceId: uuid("eservice_id"),
     eserviceName: varchar("eservice_name", { length: 255 }),
-    producerId: varchar("producer_id", { length: 36 }),
+    producerId: uuid("producer_id"),
     producerName: varchar("producer_name", { length: 2048 }),
-    versionId: varchar("version_id", { length: 36 }),
+    versionId: uuid("version_id"),
     state: varchar({ length: 255 }),
     status: varchar({ length: 2 }),
     probingEnabled: boolean("probing_enabled"),

--- a/packages/probing-eservice-operations/src/services/dbService.ts
+++ b/packages/probing-eservice-operations/src/services/dbService.ts
@@ -2,6 +2,7 @@ import { and, eq, sql, like, asc, SQL } from "drizzle-orm";
 import {
   eservicesInProbing,
   tenantsInProbing,
+  tenantsAllowListInProbing,
   eserviceProbingRequestsInProbing,
   eserviceProbingResponsesInProbing,
   eserviceViewInProbing,
@@ -104,6 +105,7 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
         eserviceId,
         versionId,
         eserviceName: eServiceUpdated.eserviceName,
+        producerId: eServiceUpdated.producerId,
         producerName: tenant.tenantName || "N/D",
         basePath: eServiceUpdated.basePath,
         eserviceTechnology: eServiceUpdated.technology,
@@ -124,6 +126,7 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
           target: [eservicesInProbing.eserviceId, eservicesInProbing.versionId],
           set: {
             eserviceName: eserviceData.eserviceName,
+            producerId: eserviceData.producerId,
             producerName: eserviceData.producerName,
             basePath: eserviceData.basePath,
             eserviceTechnology: eserviceData.eserviceTechnology,
@@ -256,8 +259,34 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
       const predicate = addPredicateEservices(filters);
 
       const baseQuery = db
-        .select()
+        .select({
+          id: eserviceViewInProbing.id,
+          eserviceId: eserviceViewInProbing.eserviceId,
+          eserviceName: eserviceViewInProbing.eserviceName,
+          producerId: eserviceViewInProbing.producerId,
+          producerName: eserviceViewInProbing.producerName,
+          versionId: eserviceViewInProbing.versionId,
+          state: eserviceViewInProbing.state,
+          status: eserviceViewInProbing.status,
+          probingEnabled: eserviceViewInProbing.probingEnabled,
+          versionNumber: eserviceViewInProbing.versionNumber,
+          responseReceived: eserviceViewInProbing.responseReceived,
+          lastRequest: eserviceViewInProbing.lastRequest,
+          pollingFrequency: eserviceViewInProbing.pollingFrequency,
+          pollingStartTime: eserviceViewInProbing.pollingStartTime,
+          pollingEndTime: eserviceViewInProbing.pollingEndTime,
+          basePath: eserviceViewInProbing.basePath,
+          eserviceTechnology: eserviceViewInProbing.eserviceTechnology,
+          audience: eserviceViewInProbing.audience,
+        })
         .from(eserviceViewInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(
+            eserviceViewInProbing.producerId,
+            tenantsAllowListInProbing.tenantId,
+          ),
+        )
         .where(predicate.where);
 
       const content = await baseQuery
@@ -268,6 +297,13 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
       const countRes = await db
         .select({ count: sql<number>`count(*)` })
         .from(eserviceViewInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(
+            eserviceViewInProbing.producerId,
+            tenantsAllowListInProbing.tenantId,
+          ),
+        )
         .where(predicate.where);
 
       return {
@@ -302,6 +338,10 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
           pollingFrequency: eservicesInProbing.pollingFrequency,
         })
         .from(eservicesInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(eservicesInProbing.producerId, tenantsAllowListInProbing.tenantId),
+        )
         .where(eq(eservicesInProbing.id, eserviceRecordId))
         .limit(1);
 
@@ -332,6 +372,13 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
           pollingFrequency: eserviceViewInProbing.pollingFrequency,
         })
         .from(eserviceViewInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(
+            eserviceViewInProbing.producerId,
+            tenantsAllowListInProbing.tenantId,
+          ),
+        )
         .where(eq(eserviceViewInProbing.id, eserviceRecordId))
         .orderBy(asc(eserviceViewInProbing.id))
         .limit(1);
@@ -357,7 +404,14 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
           basePath: eserviceViewInProbing.basePath,
           audience: eserviceViewInProbing.audience,
         })
-        .from(eserviceViewInProbing);
+        .from(eserviceViewInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(
+            eserviceViewInProbing.producerId,
+            tenantsAllowListInProbing.tenantId,
+          ),
+        );
 
       const readyPredicate = addPredicateEservicesReadyForPolling();
 
@@ -370,6 +424,13 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
       const countRes = await db
         .select({ count: sql<number>`count(*)` })
         .from(eserviceViewInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(
+            eserviceViewInProbing.producerId,
+            tenantsAllowListInProbing.tenantId,
+          ),
+        )
         .where(readyPredicate);
 
       return {
@@ -393,6 +454,10 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
       const content = await db
         .selectDistinct({ producerName: eservicesInProbing.producerName })
         .from(eservicesInProbing)
+        .innerJoin(
+          tenantsAllowListInProbing,
+          eq(eservicesInProbing.producerId, tenantsAllowListInProbing.tenantId),
+        )
         .where(whereClause)
         .orderBy(asc(eservicesInProbing.producerName))
         .limit(limit)

--- a/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
+++ b/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
@@ -846,6 +846,7 @@ describe("eService service", async () => {
     it("should return eService in searchEservices even without probing data", async () => {
       const eService = mockEservice();
       await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
 
       const filters: probingEserviceOperationsApi.ApiSearchEservicesQuery = {
         eserviceName: eService.eserviceName,

--- a/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
+++ b/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
@@ -51,6 +51,37 @@ describe("eService service", async () => {
       expect(result.totalElements).toBe(0);
     });
 
+    it("should return only e-services whose producer is in the allow-list", async () => {
+      const allowedEservice = mockEservice({
+        eserviceName: "Allowed eService",
+        producerName: "Allowed producer",
+      });
+      const notAllowedEservice = mockEservice({
+        eserviceName: "Not allowed eService",
+        producerName: "Not allowed producer",
+      });
+
+      await addEservice(allowedEservice);
+      await addEservice(notAllowedEservice);
+      await addTenantToAllowList(allowedEservice.producerId);
+
+      const filters: probingEserviceOperationsApi.ApiSearchEservicesQuery = {
+        limit: 10,
+        offset: 0,
+      };
+
+      const result = await eserviceService.searchEservices(
+        filters,
+        genericLogger,
+      );
+
+      expect(result.totalElements).toBe(1);
+      expect(result.content[0]).toMatchObject({
+        eserviceName: allowedEservice.eserviceName,
+        producerName: allowedEservice.producerName,
+      });
+    });
+
     it("should return all e-services when no state filter is provided", async () => {
       const eService = mockEservice();
       await addEservice(eService);

--- a/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
+++ b/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
@@ -248,6 +248,15 @@ describe("eService service", async () => {
       expect(result).toHaveProperty("pollingFrequency");
     });
 
+    it("should throw an `eServiceByRecordIdNotFound` error when e-service producer is not in allow-list", async () => {
+      const eService = mockEservice();
+      const eserviceRecordId = await addEservice(eService);
+
+      await expect(
+        eserviceService.getEserviceMainData(eserviceRecordId, genericLogger),
+      ).rejects.toThrowError(eServiceByRecordIdNotFound(eserviceRecordId));
+    });
+
     it("should throw an `eServiceByRecordIdNotFound` error when the e-service is not found", async () => {
       await expect(
         eserviceService.getEserviceMainData(99, genericLogger),
@@ -283,6 +292,24 @@ describe("eService service", async () => {
       expect(result).toHaveProperty("responseReceived");
       expect(result).toHaveProperty("lastRequest");
       expect(result).toHaveProperty("responseStatus", responseStatus.ok);
+    });
+
+    it("should throw an `eServiceByRecordIdNotFound` error when e-service producer is not in allow-list", async () => {
+      const eService = mockEservice();
+      const eserviceRecordId = await addEservice(eService);
+      await addEserviceProbingRequest({
+        eservicesRecordId: eserviceRecordId,
+        lastRequest: new Date().toISOString(),
+      });
+      await addEserviceProbingResponse({
+        eservicesRecordId: eserviceRecordId,
+        responseReceived: new Date().toISOString(),
+        status: responseStatus.ok,
+      });
+
+      await expect(
+        eserviceService.getEserviceProbingData(eserviceRecordId, genericLogger),
+      ).rejects.toThrowError(eServiceByRecordIdNotFound(eserviceRecordId));
     });
 
     it("should throw an `eServiceByRecordIdNotFound` error when the e-service is not found", async () => {
@@ -335,6 +362,36 @@ describe("eService service", async () => {
 
       const producers = await eserviceService.getEservicesProducers(filters);
       expect(producers.content.length).toBe(0);
+    });
+
+    it("should return only producers in allow-list", async () => {
+      const allowed = mockEservice({ producerName: "Allowed Producer" });
+      const notAllowed = mockEservice({ producerName: "Not Allowed Producer" });
+
+      await addEservice(allowed);
+      await addEservice(notAllowed);
+      await addTenantToAllowList(allowed.producerId);
+
+      const result = await eserviceService.getEservicesProducers({
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result.content).toContain("Allowed Producer");
+      expect(result.content).not.toContain("Not Allowed Producer");
+    });
+
+    it("should return empty list when filtering by a producer not in allow-list", async () => {
+      const notAllowed = mockEservice({ producerName: "Not Allowed Producer" });
+      await addEservice(notAllowed);
+
+      const result = await eserviceService.getEservicesProducers({
+        producerName: notAllowed.producerName,
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result.content).toHaveLength(0);
     });
 
     it("should return all producers when no producer name is provided", async () => {

--- a/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
+++ b/packages/probing-eservice-operations/test/integration/eserviceService.test.ts
@@ -12,6 +12,7 @@ import {
   addEserviceProbingRequest,
   addEserviceProbingResponse,
   addTenant,
+  addTenantToAllowList,
   db,
   eserviceService,
 } from "../utils.js";
@@ -53,6 +54,7 @@ describe("eService service", async () => {
     it("should return all e-services when no state filter is provided", async () => {
       const eService = mockEservice();
       await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
 
       const filters: probingEserviceOperationsApi.ApiSearchEservicesQuery = {
         eserviceName: eService.eserviceName,
@@ -72,6 +74,7 @@ describe("eService service", async () => {
     it("should return all e-services when filtering by all state values (N_D, OFFLINE, ONLINE)", async () => {
       const eService = mockEservice({ state: eserviceInteropState.inactive });
       const eserviceRecordId = await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
 
       await addEserviceProbingRequest({
         eservicesRecordId: eserviceRecordId,
@@ -115,6 +118,7 @@ describe("eService service", async () => {
       });
 
       await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
 
       const filters: probingEserviceOperationsApi.ApiSearchEservicesQuery = {
         eserviceName: eService.eserviceName,
@@ -140,6 +144,7 @@ describe("eService service", async () => {
     it("should return e-services when state is INACTIVE and filtering by OFFLINE", async () => {
       const eService = mockEservice();
       const eserviceRecordId = await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
       await addEserviceProbingRequest({
         eservicesRecordId: eserviceRecordId,
         lastRequest: new Date().toISOString(),
@@ -176,6 +181,7 @@ describe("eService service", async () => {
       });
 
       const recordId = await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
 
       await addEserviceProbingRequest({
         eservicesRecordId: recordId,
@@ -201,6 +207,7 @@ describe("eService service", async () => {
     it("should successfully retrieve e-service main data and return a valid MainDataEserviceResponse", async () => {
       const eService = mockEservice();
       const eserviceRecordId = await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
       const result = await eserviceService.getEserviceMainData(
         eserviceRecordId,
         genericLogger,
@@ -221,6 +228,7 @@ describe("eService service", async () => {
     it("should successfully retrieve e-service probing data and return a valid ProbingDataEserviceResponse", async () => {
       const eService = mockEservice();
       const eserviceRecordId = await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
       await addEserviceProbingRequest({
         eservicesRecordId: eserviceRecordId,
         lastRequest: new Date().toISOString(),
@@ -271,6 +279,7 @@ describe("eService service", async () => {
 
       await addEservice(eService1);
       await addEservice(eService2);
+      await addTenantToAllowList(eService2.producerId);
 
       const result = await eserviceService.getEservicesReadyForPolling(
         { offset: 0, limit: 2 },
@@ -303,6 +312,8 @@ describe("eService service", async () => {
 
       await addEservice(eService1);
       await addEservice(eService2);
+      await addTenantToAllowList(eService1.producerId);
+      await addTenantToAllowList(eService2.producerId);
 
       const filters: probingEserviceOperationsApi.ApiGetProducersQuery = {
         limit: 10,
@@ -319,6 +330,7 @@ describe("eService service", async () => {
     it("should return a non-empty list when given a specific valid producer name", async () => {
       const eService = mockEservice({ producerName: "eService producer 001" });
       await addEservice(eService);
+      await addTenantToAllowList(eService.producerId);
 
       const filters: probingEserviceOperationsApi.ApiGetProducersQuery = {
         producerName: eService.producerName,
@@ -337,6 +349,8 @@ describe("eService service", async () => {
 
       await addEservice(eService1);
       await addEservice(eService2);
+      await addTenantToAllowList(eService1.producerId);
+      await addTenantToAllowList(eService2.producerId);
 
       const filters: probingEserviceOperationsApi.ApiGetProducersQuery = {
         producerName: "eService producer",

--- a/packages/probing-eservice-operations/test/utils.ts
+++ b/packages/probing-eservice-operations/test/utils.ts
@@ -9,6 +9,7 @@ import {
   eserviceProbingRequestsInProbing,
   eserviceProbingResponsesInProbing,
   tenantsInProbing,
+  tenantsAllowListInProbing,
 } from "../src/db/drizzle/schema.js";
 import { eq } from "drizzle-orm";
 import { DBService, dbServiceBuilder } from "../src/services/dbService.js";
@@ -55,6 +56,7 @@ export const mockEservice = (
   partialEserviceData: Partial<EserviceInsert> = {},
 ) => ({
   eserviceName: "eService 001",
+  producerId: uuidv4(),
   producerName: "eService producer 001",
   versionNumber: 1,
   state: eserviceInteropState.inactive,
@@ -113,6 +115,14 @@ export const addTenant = async (
     })
     .returning();
   return tenant;
+};
+
+export const addTenantToAllowList = async (tenantId: string | null) => {
+  await db
+    .insert(tenantsAllowListInProbing)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    .values({ tenantId: tenantId! })
+    .onConflictDoNothing();
 };
 
 export const getEservice = async (

--- a/packages/probing-eservice-operations/test/utils.ts
+++ b/packages/probing-eservice-operations/test/utils.ts
@@ -118,10 +118,16 @@ export const addTenant = async (
 };
 
 export const addTenantToAllowList = async (tenantId: string | null) => {
+  if (!tenantId) {
+    throw new Error("tenantId is required to add to allow-list");
+  }
+  await db
+    .insert(tenantsInProbing)
+    .values({ tenantId, tenantName: "Allow-listed tenant" })
+    .onConflictDoNothing();
   await db
     .insert(tenantsAllowListInProbing)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    .values({ tenantId: tenantId! })
+    .values({ tenantId })
     .onConflictDoNothing();
 };
 

--- a/packages/probing-eservice-operations/test/utilsSetupTestContainers.ts
+++ b/packages/probing-eservice-operations/test/utilsSetupTestContainers.ts
@@ -2,7 +2,11 @@ import { sql } from "drizzle-orm";
 import { DrizzleReturnType } from "../src/db/types.js";
 import { makeDrizzleConnection } from "../src/db/utils.js";
 import { DbConfig } from "../src/utilities/dbConfig.js";
-import { eservicesInProbing, tenantsInProbing } from "../src/db/index.js";
+import {
+  eservicesInProbing,
+  tenantsInProbing,
+  tenantsAllowListInProbing,
+} from "../src/db/index.js";
 
 export async function setupTestContainersVitest(dbConfig: DbConfig): Promise<{
   postgresDB: DrizzleReturnType;
@@ -13,6 +17,7 @@ export async function setupTestContainersVitest(dbConfig: DbConfig): Promise<{
   return {
     postgresDB,
     cleanup: async (): Promise<void> => {
+      await postgresDB.delete(tenantsAllowListInProbing).where(sql`TRUE`);
       await postgresDB.delete(tenantsInProbing).where(sql`TRUE`);
       await postgresDB.delete(eservicesInProbing).where(sql`TRUE`);
     },


### PR DESCRIPTION
## Jira Issue
[PIN-9734](https://pagopa.atlassian.net/browse/PIN-9734)

## Context/Why
- In early probing phases, only eServices from a restricted set of Producers (tenants) must be processed.
- Ensure both UI listing and scheduler polling only operate on allowed tenants.

## Services Impacted
- `probing-eservice-operations`
- `probing-scheduler`

## Key Changes
- Add DB table `tenants_allow_list` (tenant identifier list).
- Persist `producerId` into `eservices.producer_id`.
- Apply allow-list filtering to:
  - GET /eservices (used by frontend)
  - GET /eservices/polling (used by scheduler)
  - GET /eservices/mainData/:eserviceRecordId (used by frontend)
  - GET /eservices/probingData/:eserviceRecordId (used by frontend)
  - GET /producers (used by frontend)
- Update integration tests accordingly.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard 

[PIN-9734]: https://pagopa.atlassian.net/browse/PIN-9734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ