### PR TITLE
fix(PIN-9992): remove archived eService version

### DIFF
--- a/packages/api-clients/open-api/probingEserviceOperationsApi.yaml
+++ b/packages/api-clients/open-api/probingEserviceOperationsApi.yaml
@@ -638,6 +638,58 @@ paths:
                     detail: >-
                       The server is currently down for maintenance. Please try
                       again later.
+  "/eservices/{eserviceId}/versions/{versionId}/deleteEserviceVersion":
+    delete:
+      summary: Delete eservice version
+      operationId: deleteEserviceVersion
+      parameters:
+        - in: header
+          name: x-correlation-id
+          required: true
+          schema:
+            $ref: "#/components/schemas/CorrelationId"
+        - name: eserviceId
+          in: path
+          required: true
+          description: The e-service ID
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          description: The descriptor/version ID
+          schema:
+            type: string
+            format: uuid
+      tags:
+        - EServices
+      responses:
+        "204":
+          description: No content
+        "400":
+          description: The provided input is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "500":
+          description: A managed error has occurred during the request elaboration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+              example:
+                type: "about:blank"
+                status: 500
+                title: Internal Server Error
+                detail: There is a problem processing the request on the server.
+                correlationId: string
+                errors:
+                  - code: 000-1234
+                    detail: >-
+                      The server is currently down for maintenance. Please try
+                      again later.
   "/eservices/polling":
     get:
       summary: Retrieve e-services ready for polling

--- a/packages/api-clients/src/probingEserviceOperationsApi.ts
+++ b/packages/api-clients/src/probingEserviceOperationsApi.ts
@@ -125,6 +125,23 @@ export type ApiDeleteEserviceResponse = ZodiosResponseByPath<
   "/eservices/:eserviceId/deleteEservice"
 >;
 
+// ---------- Delete eService Version ----------
+export type ApiDeleteEserviceVersionParams = ZodiosPathParamsByPath<
+  EServiceApi,
+  "delete",
+  "/eservices/:eserviceId/versions/:versionId/deleteEserviceVersion"
+>;
+export type ApiDeleteEserviceVersionHeaders = ZodiosHeaderParamsByPath<
+  EServiceApi,
+  "delete",
+  "/eservices/:eserviceId/versions/:versionId/deleteEserviceVersion"
+>;
+export type ApiDeleteEserviceVersionResponse = ZodiosResponseByPath<
+  EServiceApi,
+  "delete",
+  "/eservices/:eserviceId/versions/:versionId/deleteEserviceVersion"
+>;
+
 // ---------- Search / List eServices ----------
 export type ApiSearchEservicesQuery = ZodiosQueryParamsByPath<
   EServiceApi,

--- a/packages/probing-eservice-event-consumer/src/handlers/messageHandlerV1.ts
+++ b/packages/probing-eservice-event-consumer/src/handlers/messageHandlerV1.ts
@@ -39,6 +39,10 @@ export async function handleMessageV1(
         const { eservice } = evt.data;
 
         for (const descriptor of eservice.descriptors) {
+          if (descriptor.state === EServiceDescriptorStateV1.ARCHIVED) {
+            continue;
+          }
+
           const parsedBasePath = z
             .array(z.string().transform(sanitizeData))
             .parse(descriptor.serverUrls);

--- a/packages/probing-eservice-event-consumer/src/handlers/messageHandlerV2.ts
+++ b/packages/probing-eservice-event-consumer/src/handlers/messageHandlerV2.ts
@@ -42,6 +42,10 @@ export async function handleMessageV2(
         }
 
         for (const descriptor of eservice.descriptors) {
+          if (descriptor.state === EServiceDescriptorStateV2.ARCHIVED) {
+            continue;
+          }
+
           const parsedBasePath = z
             .array(z.string().transform(sanitizeData))
             .parse(descriptor.serverUrls);
@@ -75,6 +79,23 @@ export async function handleMessageV2(
     )
     .with(
       {
+        type: "EServiceDescriptorArchived",
+      },
+      async (evt) => {
+        const { eservice, descriptorId } = evt.data;
+        if (!eservice || !descriptorId) {
+          throw kafkaMessageMissingData(config.kafkaTopic, event.type);
+        }
+
+        await operationsService.deleteEserviceVersion(
+          { ...correlationIdToHeader(ctx.correlationId) },
+          { eserviceId: eservice.id, versionId: descriptorId },
+          logger,
+        );
+      },
+    )
+    .with(
+      {
         type: "EServiceDeleted",
       },
       async (evt) => {
@@ -103,7 +124,6 @@ export async function handleMessageV2(
           "EServiceDraftDescriptorDeleted",
           "EServiceDescriptorAdded",
           "EServiceDescriptorActivated",
-          "EServiceDescriptorArchived",
           "EServiceDescriptorSuspended",
           "EServiceDraftDescriptorUpdated",
           "EServiceDescriptorAttributesUpdated",

--- a/packages/probing-eservice-event-consumer/src/models/domain/errors.ts
+++ b/packages/probing-eservice-event-consumer/src/models/domain/errors.ts
@@ -2,6 +2,7 @@ import { InternalError } from "pagopa-interop-probing-models";
 
 export const errorCodes = {
   errorDeleteEservice: "ERROR_DELETE_ESERVICE",
+  errorDeleteEserviceVersion: "ERROR_DELETE_ESERVICE_VERSION",
   errorSaveEservice: "ERROR_SAVE_ESERVICE",
 } as const;
 
@@ -14,6 +15,17 @@ export function errorDeleteEservice(
   return new InternalError({
     detail: `Error deleting eService: ${eserviceId}. Details: ${error}`,
     code: "errorDeleteEservice",
+  });
+}
+
+export function errorDeleteEserviceVersion(
+  eserviceId: string,
+  versionId: string,
+  error: unknown,
+): InternalError<ErrorCodes> {
+  return new InternalError({
+    detail: `Error deleting eService version: ${eserviceId}, versionId: ${versionId}. Details: ${error}`,
+    code: "errorDeleteEserviceVersion",
   });
 }
 

--- a/packages/probing-eservice-event-consumer/src/services/operationsService.ts
+++ b/packages/probing-eservice-event-consumer/src/services/operationsService.ts
@@ -3,6 +3,7 @@ import { probingEserviceOperationsApi } from "pagopa-interop-probing-api-clients
 import {
   errorSaveEservice,
   errorDeleteEservice,
+  errorDeleteEserviceVersion,
 } from "../models/domain/errors.js";
 import { Logger } from "pagopa-interop-probing-commons";
 
@@ -54,6 +55,29 @@ export const operationsServiceBuilder = (
         });
       } catch (error: unknown) {
         throw errorDeleteEservice(params.eserviceId, error);
+      }
+    },
+
+    async deleteEserviceVersion(
+      headers: probingEserviceOperationsApi.ApiDeleteEserviceVersionHeaders,
+      params: probingEserviceOperationsApi.ApiDeleteEserviceVersionParams,
+      logger: Logger,
+    ): Promise<probingEserviceOperationsApi.ApiDeleteEserviceVersionResponse> {
+      try {
+        logger.info(
+          `eService version deleted with eserviceId: ${params.eserviceId}, versionId: ${params.versionId}.`,
+        );
+
+        await operationsApiClient.deleteEserviceVersion(undefined, {
+          headers,
+          params,
+        });
+      } catch (error: unknown) {
+        throw errorDeleteEserviceVersion(
+          params.eserviceId,
+          params.versionId,
+          error,
+        );
       }
     },
   };

--- a/packages/probing-eservice-event-consumer/src/services/operationsService.ts
+++ b/packages/probing-eservice-event-consumer/src/services/operationsService.ts
@@ -18,10 +18,6 @@ export const operationsServiceBuilder = (
       logger: Logger,
     ): Promise<probingEserviceOperationsApi.ApiSaveEserviceResponse> {
       try {
-        logger.info(
-          `eService saved with eserviceId: ${params.eserviceId}, versionId: ${params.versionId}, tenantId: ${data.producerId}.`,
-        );
-
         await operationsApiClient.saveEservice(
           {
             producerId: data.producerId,
@@ -37,6 +33,10 @@ export const operationsServiceBuilder = (
             params,
           },
         );
+
+        logger.info(
+          `eService saved with eserviceId: ${params.eserviceId}, versionId: ${params.versionId}, tenantId: ${data.producerId}.`,
+        );
       } catch (error: unknown) {
         throw errorSaveEservice(params.eserviceId, data.producerId, error);
       }
@@ -47,12 +47,12 @@ export const operationsServiceBuilder = (
       logger: Logger,
     ): Promise<probingEserviceOperationsApi.ApiDeleteEserviceResponse> {
       try {
-        logger.info(`eService deleted with eserviceId: ${params.eserviceId}.`);
-
         await operationsApiClient.deleteEservice(undefined, {
           headers,
           params,
         });
+
+        logger.info(`eService deleted with eserviceId: ${params.eserviceId}.`);
       } catch (error: unknown) {
         throw errorDeleteEservice(params.eserviceId, error);
       }
@@ -64,14 +64,14 @@ export const operationsServiceBuilder = (
       logger: Logger,
     ): Promise<probingEserviceOperationsApi.ApiDeleteEserviceVersionResponse> {
       try {
-        logger.info(
-          `eService version deleted with eserviceId: ${params.eserviceId}, versionId: ${params.versionId}.`,
-        );
-
         await operationsApiClient.deleteEserviceVersion(undefined, {
           headers,
           params,
         });
+
+        logger.info(
+          `eService version deleted with eserviceId: ${params.eserviceId}, versionId: ${params.versionId}.`,
+        );
       } catch (error: unknown) {
         throw errorDeleteEserviceVersion(
           params.eserviceId,

--- a/packages/probing-eservice-event-consumer/test/messageHandlerV2.test.ts
+++ b/packages/probing-eservice-event-consumer/test/messageHandlerV2.test.ts
@@ -20,7 +20,10 @@ import {
   EServiceDescriptorStateV2,
   EServiceEventV2,
 } from "@pagopa/interop-outbound-models";
-import { errorSaveEservice } from "../src/models/domain/errors.js";
+import {
+  errorDeleteEserviceVersion,
+  errorSaveEservice,
+} from "../src/models/domain/errors.js";
 
 const apiClient = probingEserviceOperationsApi.createEServicesApiClient(
   config.operationsBaseUrl,
@@ -61,6 +64,29 @@ describe("Message handler V2 - EService tests", () => {
       ).resolves.not.toThrow();
 
       expect(apiClient.saveEservice).toHaveBeenCalledTimes(1);
+    });
+
+    it("should skip archived descriptors on EServiceAdded", async () => {
+      const eServiceId = uuidv4();
+      const descriptorId = uuidv4();
+      const producerId = "producer-test-idV2";
+
+      const eServiceV2 = createV2Event(
+        eServiceId,
+        descriptorId,
+        producerId,
+        EServiceDescriptorStateV2.ARCHIVED,
+      );
+
+      const eServiceV2Event = createEserviceAddedEventV2(eServiceV2);
+
+      vi.spyOn(apiClient, "saveEservice").mockResolvedValueOnce(undefined);
+
+      await expect(
+        handleMessageV2(eServiceV2Event, operationsService, ctx, genericLogger),
+      ).resolves.not.toThrow();
+
+      expect(apiClient.saveEservice).toHaveBeenCalledTimes(0);
     });
 
     it("save a new Eservice for EServiceAdded event should return an exception kafkaMessageMissingData", async () => {
@@ -175,6 +201,73 @@ describe("Message handler V2 - EService tests", () => {
     });
   });
 
+  describe("EServiceDescriptorArchived Event", () => {
+    it("should delete a version for EServiceDescriptorArchived event", async () => {
+      const eServiceId = uuidv4();
+      const descriptorId = uuidv4();
+      const producerId = "producer-test-idV2";
+
+      const eservice = createV2Event(
+        eServiceId,
+        descriptorId,
+        producerId,
+        EServiceDescriptorStateV2.PUBLISHED,
+      );
+
+      const archivedEvent = {
+        event_version: 2,
+        version: 1,
+        type: "EServiceDescriptorArchived",
+        timestamp: new Date(),
+        stream_id: "1",
+        data: { descriptorId, eservice },
+      } as EServiceEventV2;
+
+      vi.spyOn(apiClient, "deleteEserviceVersion").mockResolvedValueOnce(
+        undefined,
+      );
+
+      await expect(
+        handleMessageV2(archivedEvent, operationsService, ctx, genericLogger),
+      ).resolves.not.toThrow();
+
+      expect(apiClient.deleteEserviceVersion).toHaveBeenCalledTimes(1);
+    });
+
+    it("should wrap errors in errorDeleteEserviceVersion", async () => {
+      const eServiceId = uuidv4();
+      const descriptorId = uuidv4();
+      const producerId = "producer-test-idV2";
+
+      const eservice = createV2Event(
+        eServiceId,
+        descriptorId,
+        producerId,
+        EServiceDescriptorStateV2.PUBLISHED,
+      );
+
+      const archivedEvent = {
+        event_version: 2,
+        version: 1,
+        type: "EServiceDescriptorArchived",
+        timestamp: new Date(),
+        stream_id: "1",
+        data: { descriptorId, eservice },
+      } as EServiceEventV2;
+
+      const apiClientError = mockApiClientError(500, "Internal server error");
+      vi.spyOn(apiClient, "deleteEserviceVersion").mockRejectedValueOnce(
+        apiClientError,
+      );
+
+      await expect(
+        handleMessageV2(archivedEvent, operationsService, ctx, genericLogger),
+      ).rejects.toThrow(
+        errorDeleteEserviceVersion(eServiceId, descriptorId, apiClientError),
+      );
+    });
+  });
+
   describe("EserviceClone Event", () => {
     it("clone an Eservice for EserviceClone event should return a successfully response", async () => {
       vi.spyOn(apiClient, "saveEservice").mockResolvedValue(undefined);
@@ -206,7 +299,6 @@ describe("Message handler V2 - EService tests", () => {
         { type: "EServiceDraftDescriptorDeleted" },
         { type: "EServiceDescriptorAdded" },
         { type: "EServiceDescriptorActivated" },
-        { type: "EServiceDescriptorArchived" },
         { type: "EServiceDescriptorSuspended" },
         { type: "EServiceDraftDescriptorUpdated" },
         { type: "EServiceDescriptorAttributesUpdated" },

--- a/packages/probing-eservice-operations/src/routers/eserviceRouter.ts
+++ b/packages/probing-eservice-operations/src/routers/eserviceRouter.ts
@@ -121,6 +121,28 @@ const eServiceRouter = (
         return res.status(errorRes.status).json(errorRes).end();
       }
     })
+    .delete(
+      "/eservices/:eserviceId/versions/:versionId/deleteEserviceVersion",
+      async (req, res) => {
+        try {
+          await eServiceService.deleteEserviceVersion(
+            req.params.eserviceId,
+            req.params.versionId,
+            logger(req.ctx),
+          );
+
+          return res.status(204).end();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            errorMapper,
+            logger(req.ctx),
+            req.ctx.correlationId,
+          );
+          return res.status(errorRes.status).json(errorRes).end();
+        }
+      },
+    )
     .post(
       "/eservices/:eserviceRecordId/updateLastRequest",
       async (req, res) => {

--- a/packages/probing-eservice-operations/src/services/dbService.ts
+++ b/packages/probing-eservice-operations/src/services/dbService.ts
@@ -148,6 +148,23 @@ export function dbServiceBuilder(db: DrizzleReturnType) {
       return deletedEservice;
     },
 
+    async deleteEserviceVersion(
+      eserviceId: string,
+      versionId: string,
+    ): Promise<{ id: number } | undefined> {
+      const [deletedEserviceVersion] = await db
+        .delete(eservicesInProbing)
+        .where(
+          and(
+            eq(eservicesInProbing.eserviceId, eserviceId),
+            eq(eservicesInProbing.versionId, versionId),
+          ),
+        )
+        .returning({ id: eservicesInProbing.id });
+
+      return deletedEserviceVersion;
+    },
+
     async saveTenant(tenantData: TenantSaveRequest): Promise<void> {
       await db
         .insert(tenantsInProbing)

--- a/packages/probing-eservice-operations/src/services/eserviceService.ts
+++ b/packages/probing-eservice-operations/src/services/eserviceService.ts
@@ -107,6 +107,22 @@ export function eServiceServiceBuilder(dbService: DBService) {
       }
     },
 
+    async deleteEserviceVersion(
+      eserviceId: string,
+      versionId: string,
+      logger: Logger,
+    ): Promise<probingEserviceOperationsApi.ApiDeleteEserviceVersionResponse> {
+      const deletedEserviceVersion = await dbService.deleteEserviceVersion(
+        eserviceId,
+        versionId,
+      );
+      if (!deletedEserviceVersion) {
+        logger.error(
+          `EService with eserviceId ${eserviceId} and versionId ${versionId} not found during delete version operation`,
+        );
+      }
+    },
+
     async updateEserviceLastRequest(
       eserviceRecordId: number,
       payload: probingEserviceOperationsApi.ApiUpdateLastRequestPayload,

--- a/packages/probing-eservice-operations/test/api/deleteEserviceVersion.test.ts
+++ b/packages/probing-eservice-operations/test/api/deleteEserviceVersion.test.ts
@@ -1,0 +1,51 @@
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import { api, eServiceService } from "../vitest.api.setup.js";
+import { genericError } from "pagopa-interop-probing-models";
+
+describe("delete /eservices/{eServiceId}/versions/{versionId}/deleteEserviceVersion router test", () => {
+  const mockEserviceId = uuidv4();
+  const mockVersionId = uuidv4();
+
+  eServiceService.deleteEserviceVersion = vi.fn().mockResolvedValue({});
+
+  const makeRequest = async (eServiceId: string, versionId: string) =>
+    request(api)
+      .delete(
+        `/eservices/${eServiceId}/versions/${versionId}/deleteEserviceVersion`,
+      )
+      .set("X-Correlation-Id", uuidv4());
+
+  it("should return 204 when deletion succeeds", async () => {
+    const res = await makeRequest(mockEserviceId, mockVersionId);
+    expect(res.status).toBe(204);
+  });
+
+  it.each([
+    {
+      error: genericError("Unexpected error"),
+      expectedStatus: 500,
+    },
+  ])(
+    "should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      eServiceService.deleteEserviceVersion = vi
+        .fn()
+        .mockRejectedValueOnce(error);
+
+      const res = await makeRequest(mockEserviceId, mockVersionId);
+      expect(res.status).toBe(expectedStatus);
+    },
+  );
+
+  it("should return 400 if invalid eserviceId is provided", async () => {
+    const res = await makeRequest("invalid-id", mockVersionId);
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 400 if invalid versionId is provided", async () => {
+    const res = await makeRequest(mockEserviceId, "invalid-id");
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Jira Issue
[PIN-9992](https://pagopa.atlassian.net/browse/PIN-9992)

## Context/Why
- Archived eService descriptor versions could remain visible among monitored services because the archive event was not handled.
- This fix removes archived versions from probing storage and prevents archived descriptors from being persisted again during event processing/replays.

## Services Impacted
- probing-eservice-event-consumer
- probing-eservice-operations
- api-clients

## Key Changes
- Handle `EServiceDescriptorArchived` (V2) by deleting the archived eService version (descriptorId) from storage.
- Skip persisting descriptors in `ARCHIVED` state during upsert processing.
- Add Operations API endpoint to delete a single eService version and update OpenAPI spec.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] API and integration tests updated
- [x] OpenAPI spec updated

[PIN-9992]: https://pagopa.atlassian.net/browse/PIN-9992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ