### PR TITLE
Add OneTrust cookie banner

### DIFF
--- a/packages/probing-frontend/index.html
+++ b/packages/probing-frontend/index.html
@@ -35,5 +35,16 @@
         version: [],
       }
     </script>
+
+    <script
+      src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+      data-language="it"
+      type="text/javascript"
+      charset="UTF-8"
+      data-domain-script="019df897-b3e7-752c-b33a-b32f7ad91427"
+    ></script>
+    <script type="text/javascript">
+      function OptanonWrapper() {}
+    </script>
   </body>
 </html>

--- a/packages/probing-frontend/index.html
+++ b/packages/probing-frontend/index.html
@@ -4,24 +4,24 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    
+
     <title>Monitoraggio e-service | PDND Interoperabilità | PagoPA</title>
     <meta
       name="description"
       content="Il servizio di monitoraggio che verifica la disponibilità e lo stato degli e-service presenti sulla Piattaforma Digitale Nazionale Dati (PDND)."
     />
     <meta name="theme-color" content="#00a1b0" />
-    <link rel="manifest" href="./manifest.webmanifest" crossorigin="anonymous" />
-    <link rel="icon" href="./favicon-32x32.png" type="image/png" />
-    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" sizes="48x48" href="./icons/icon-48x48.png" />
-    <link rel="apple-touch-icon" sizes="72x72" href="./icons/icon-72x72.png" />
-    <link rel="apple-touch-icon" sizes="96x96" href="./icons/icon-96x96.png" />
-    <link rel="apple-touch-icon" sizes="144x144" href="./icons/icon-144x144.png" />
-    <link rel="apple-touch-icon" sizes="192x192" href="./icons/icon-192x192.png" />
-    <link rel="apple-touch-icon" sizes="256x256" href="./icons/icon-256x256.png" />
-    <link rel="apple-touch-icon" sizes="384x384" href="./icons/icon-384x384.png" />
-    <link rel="apple-touch-icon" sizes="512x512" href="./icons/icon-512x512.png" />
+    <link rel="manifest" href="/manifest.webmanifest" crossorigin="anonymous" />
+    <link rel="icon" href="/favicon-32x32.png" type="image/png" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" sizes="48x48" href="/icons/icon-48x48.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="/icons/icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="96x96" href="/icons/icon-96x96.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="/icons/icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192x192.png" />
+    <link rel="apple-touch-icon" sizes="256x256" href="/icons/icon-256x256.png" />
+    <link rel="apple-touch-icon" sizes="384x384" href="/icons/icon-384x384.png" />
+    <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512x512.png" />
   </head>
   <body>
     <noscript>Abilita JavaScript per utilizzare quest'applicazione</noscript>


### PR DESCRIPTION
OneTrust policies don't seem to work without an explicit cookie banner. Adding it.

Bonus: fixed wrong path for favicons and manifest